### PR TITLE
Fix path + subpaths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asledgehammer/tstl-pipewrench",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asledgehammer/tstl-pipewrench",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "typescript": "^4.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asledgehammer/tstl-pipewrench",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "license": "MIT",
   "main": "./dist/index.js",
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ const applyReimportScript = (lua: string): string => {
   for (const line of lines) {
     if (
       line.indexOf('local ') === 0 &&
-      line.indexOf('____PipeWrench.') !== -1
+      line.indexOf('____pipewrench.') !== -1
     ) {
       assignments.push(line.replace('local ', ''));
     }
@@ -90,9 +90,20 @@ const applyReimportScript = (lua: string): string => {
 const handle_file = (file: tstl.EmitFile) => {
   if (file.code.length === 0) return;
   let scope: Scope = 'none'
-  if (file.outputPath.startsWith('media/lua/client')) scope = 'client';
-  else if (file.outputPath.startsWith('media/lua/server')) scope = 'server';
-  else if (file.outputPath.startsWith('media/lua/shared')) scope = 'shared';
+  const fp = path.parse(file.outputPath)
+  if (fp.dir.indexOf('media/lua/client')) scope = 'client';
+  else if (fp.dir.indexOf('media/lua/server')) scope = 'server';
+  else if (fp.dir.indexOf('media/lua/shared')) scope = 'shared';
+  const split = fp.dir.split("lua_modules")
+  const isLuaModule = split.length > 1
+  if (fp.name === "lualib_bundle") {
+    file.outputPath = path.join(fp.dir, "shared/lualib_bundle.lua")
+  }
+  if (isLuaModule) {
+    file.outputPath = path.join(split[0], "shared", ...split.slice(1), fp.base)
+  }
+  console.log("OUT", fp.name, file.outputPath, scope)
+
   file.code = applyReimportScript(fixRequire(scope, file.code))
 }
 const plugin: tstl.Plugin = {


### PR DESCRIPTION
Fixing issues with mod structure.

Makes an assumption that anything in the `shared` path is accessible by its full name and not `shared/<blah>`

Haven't written a mod yet so i'm not sure if that holds true!